### PR TITLE
Fix PdoConnection::lastInsertId

### DIFF
--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -168,7 +168,7 @@ class PdoConnection implements ConnectionInterface
      */
     public function lastInsertId(?string $name = null)
     {
-        return $this->pdo->lastInsertId();
+        return $this->pdo->lastInsertId($name);
     }
 
     /**


### PR DESCRIPTION
## Summary
- forward `$name` to underlying PDO when calling `lastInsertId`

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6e2d6248326bba4bd8f84d07053