### PR TITLE
Add timestampable and DateTime edge tests

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -20,6 +20,7 @@ use TableWithoutCreatedAt;
 use TableWithoutUpdatedAt;
 use TableDateTimeClass;
 use TableColumnTypes;
+use TableIntegerTimestamps;
 
 /**
  * Tests for TimestampableBehavior class
@@ -417,5 +418,44 @@ EOF;
         $obj = new TableColumnTypes();
         $obj->save();
         $this->assertEquals($obj->getCreatedAt('U'), $obj->getUpdatedAt('U'), 'Timestampable does not set created_column and updated_column to the same value when column types are different');
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntegerTimestamps()
+    {
+        $schema = <<<EOF
+<database name="timestampable_database">
+    <table name="table_integer_timestamps">
+        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true"/>
+        <column name="name" type="VARCHAR"/>
+        <column name="created_at" type="INTEGER"/>
+        <column name="updated_at" type="INTEGER"/>
+        <behavior name="timestampable"/>
+    </table>
+</database>
+EOF;
+
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->build();
+
+        $obj = new TableIntegerTimestamps();
+        $obj->setName('foo');
+        $saveTime = time();
+        $obj->save();
+        $this->assertIsInt($obj->getCreatedAt());
+        $this->assertIsInt($obj->getUpdatedAt());
+        $this->assertTimeEquals($saveTime, $obj->getCreatedAt());
+        $this->assertTimeEquals($saveTime, $obj->getUpdatedAt());
+
+        sleep(1);
+        $obj->setName('bar');
+        $updateTime = time();
+        $obj->save();
+
+        $this->assertTimeEquals($saveTime, $obj->getCreatedAt());
+        $this->assertTimeEquals($updateTime, $obj->getUpdatedAt());
     }
 }

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -272,6 +272,28 @@ class PropelDateTimeTest extends TestCase
 
         date_default_timezone_set($originalTimezone);
     }
+
+    /**
+     * @return void
+     */
+    public function testNewInstanceWithCustomClassAndTimestamp()
+    {
+        $dt = PropelDateTime::newInstance('1312960848', null, DateTimeImmutable::class);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $dt);
+        $this->assertEquals('2011-08-10 07:20:48', $dt->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testNewInstanceWithEpochZeroAndCustomClass()
+    {
+        $dt = PropelDateTime::newInstance('0', null, DateTimeImmutable::class);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $dt);
+        $this->assertEquals('1970-01-01 00:00:00', $dt->format('Y-m-d H:i:s'));
+    }
 }
 
 class TestPropelDateTime extends PropelDateTime


### PR DESCRIPTION
## Summary
- cover integer timestamps in timestampable behavior
- ensure custom DateTime classes handle timestamps
- validate handling of epoch `0` values

## Testing
- `composer run test` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c535456b08326b5d671ffd150b6be